### PR TITLE
Issue #73: ASubtitle

### DIFF
--- a/src/ASubtitle/ASubtitle.tsx
+++ b/src/ASubtitle/ASubtitle.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+
+import * as TypographySelectors from '../typography/heading-selectors';
+import '../typography/headings.scss';
+
+const ASubtitle: React.FC<TypographySelectors.IHeading> = ({
+  as,
+  'data-testid': testid,
+  type,
+  ...props
+}) => {
+  const componentProps = {
+    ...props,
+    as: as || 'subtitle-1',
+    'data-testid': testid,
+    type: type || 'strong',
+  };
+
+  const { Component, className } = TypographySelectors.getElement(
+    componentProps,
+  );
+
+  return (
+    <Component className={className} data-testid={testid}>
+      {props.children}
+    </Component>
+  );
+};
+
+export { ASubtitle };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { ANav } from './ANav/ANav';
 import { ARow } from './ARow/ARow';
 import { ASection } from './ASection/ASection';
 import { ASpacer } from './ASpacer/ASpacer';
+import { ASubtitle } from './ASubtitle/ASubtitle';
 import { ATextArea } from './ATextArea/ATextArea';
 // import { setTheme } from './functions/set-theme';
 
@@ -42,6 +43,7 @@ export {
   ARow,
   ASection,
   ASpacer,
+  ASubtitle,
   ATextArea,
   // setTheme,
 };

--- a/src/typography/heading-selectors.tsx
+++ b/src/typography/heading-selectors.tsx
@@ -5,7 +5,15 @@ import { setFontSize } from 'aspire-components-functions';
 import * as Types from '../types';
 
 type HeadingType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'strong';
-type HeadingAs = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+type HeadingAs =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'subtitle-1'
+  | 'subtitle-2';
 
 interface IStyleProps {
   as?: HeadingAs;
@@ -96,6 +104,8 @@ const getElementClass: GetElementClass = (as) => {
     h4: 'a-h4',
     h5: 'a-h5',
     h6: 'a-h6',
+    'subtitle-1': 'a-subtitle-1',
+    'subtitle-2': 'a-subtitle-2',
   };
 
   return map[as];

--- a/test/enums/as-heading-enum.ts
+++ b/test/enums/as-heading-enum.ts
@@ -1,3 +1,12 @@
-const AS_HEADING_ENUM = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+const AS_HEADING_ENUM = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'subtitle-1',
+  'subtitle-2',
+];
 
 export { AS_HEADING_ENUM };

--- a/test/implementation/AH1.spec.tsx
+++ b/test/implementation/AH1.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH1 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h2', 'h3', 'h4', 'h5', 'h6']);
+      as = chance.pickone([
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH1 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/AH2.spec.tsx
+++ b/test/implementation/AH2.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH2 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h1', 'h3', 'h4', 'h5', 'h6']);
+      as = chance.pickone([
+        'h1',
+        'h3',
+        'h4',
+        'h5',
+        'h6',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH2 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/AH3.spec.tsx
+++ b/test/implementation/AH3.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH3 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h1', 'h2', 'h4', 'h5', 'h6']);
+      as = chance.pickone([
+        'h1',
+        'h2',
+        'h4',
+        'h5',
+        'h6',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH3 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/AH4.spec.tsx
+++ b/test/implementation/AH4.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH4 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h1', 'h2', 'h3', 'h5', 'h6']);
+      as = chance.pickone([
+        'h1',
+        'h2',
+        'h3',
+        'h5',
+        'h6',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH4 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/AH5.spec.tsx
+++ b/test/implementation/AH5.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH5 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h1', 'h2', 'h3', 'h4', 'h6']);
+      as = chance.pickone([
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h6',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH5 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/AH6.spec.tsx
+++ b/test/implementation/AH6.spec.tsx
@@ -55,7 +55,15 @@ describe('<AH6 />', () => {
     let as: TypographySelectors.HeadingAs;
 
     beforeEach(() => {
-      as = chance.pickone(['h1', 'h2', 'h3', 'h4', 'h5']);
+      as = chance.pickone([
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
       RTL.render(
         <AH6 as={as} data-testid={testid}>
           {text}

--- a/test/implementation/ASubtitle.spec.tsx
+++ b/test/implementation/ASubtitle.spec.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react';
+import * as RTL from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Chance from 'chance';
+
+import { ASubtitle } from '../../src/ASubtitle/ASubtitle';
+import * as TypographySelectors from '../../src/typography/heading-selectors';
+
+jest.mock('../../src/typography/heading-selectors');
+
+const chance = new Chance();
+const { getElement } = TypographySelectors as jest.Mocked<
+  typeof TypographySelectors
+>;
+
+describe('<ASubtitle />', () => {
+  let text: string, testid: string;
+
+  beforeEach(() => {
+    text = chance.string();
+    testid = chance.string();
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    getElement.mockReturnValue({
+      className: chance.string(),
+      // eslint-disable-next-line react/display-name
+      Component: (props) => (
+        <p data-testid={props['data-testid']}>{props.children}</p>
+      ),
+    });
+  });
+
+  afterEach(jest.resetAllMocks);
+  describe('easy path', () => {
+    beforeEach(() => {
+      RTL.render(<ASubtitle data-testid={testid}>{text}</ASubtitle>);
+    });
+    test('should get element', () => {
+      expect(getElement).toHaveBeenCalledTimes(1);
+      expect(getElement).toHaveBeenCalledWith({
+        as: 'subtitle-1',
+        children: text,
+        'data-testid': testid,
+        type: 'strong',
+      });
+    });
+    test('should be able to find by children', () => {
+      expect(RTL.screen.getByText(text)).toBeVisible();
+    });
+    test('should be able to find by testid', () => {
+      expect(RTL.screen.getByTestId(testid)).toBeVisible();
+    });
+  });
+  describe('when as is passed in props', () => {
+    let as: TypographySelectors.HeadingAs;
+
+    beforeEach(() => {
+      as = chance.pickone([
+        'h1',
+        'h2',
+        'h3',
+        'h4',
+        'h5',
+        'subtitle-1',
+        'subtitle-2',
+      ]);
+      RTL.render(
+        <ASubtitle as={as} data-testid={testid}>
+          {text}
+        </ASubtitle>,
+      );
+    });
+    test('should get element', () => {
+      expect(getElement).toHaveBeenCalledTimes(1);
+      expect(getElement).toHaveBeenCalledWith({
+        as,
+        children: text,
+        'data-testid': testid,
+        type: 'strong',
+      });
+    });
+    test('should be able to find by children', () => {
+      expect(RTL.screen.getByText(text)).toBeVisible();
+    });
+    test('should be able to find by testid', () => {
+      expect(RTL.screen.getByTestId(testid)).toBeVisible();
+    });
+  });
+  describe('when type is passed in props', () => {
+    let type: TypographySelectors.HeadingType;
+
+    beforeEach(() => {
+      type = chance.pickone(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+      RTL.render(
+        <ASubtitle data-testid={testid} type={type}>
+          {text}
+        </ASubtitle>,
+      );
+    });
+    test('should get element', () => {
+      expect(getElement).toHaveBeenCalledTimes(1);
+      expect(getElement).toHaveBeenCalledWith({
+        as: 'subtitle-1',
+        children: text,
+        'data-testid': testid,
+        type,
+      });
+    });
+    test('should be able to find by children', () => {
+      expect(RTL.screen.getByText(text)).toBeVisible();
+    });
+    test('should be able to find by testid', () => {
+      expect(RTL.screen.getByTestId(testid)).toBeVisible();
+    });
+  });
+});

--- a/test/implementation/index.spec.tsx
+++ b/test/implementation/index.spec.tsx
@@ -17,6 +17,7 @@ import * as ANavFile from '../../src/ANav/ANav';
 import * as ARowFile from '../../src/ARow/ARow';
 import * as ASectionFile from '../../src/ASection/ASection';
 import * as ASpacerFile from '../../src/ASpacer/ASpacer';
+import * as ASubtitleFile from '../../src/ASubtitle/ASubtitle';
 import * as ATextAreaFile from '../../src/ATextArea/ATextArea';
 import * as AspireComponentsReact from '../../src';
 
@@ -39,6 +40,7 @@ jest.mock('../../src/ANav/ANav');
 jest.mock('../../src/ARow/ARow');
 jest.mock('../../src/ASection/ASection');
 jest.mock('../../src/ASpacer/ASpacer');
+jest.mock('../../src/ASubtitle/ASubtitle');
 jest.mock('../../src/ATextArea/ATextArea');
 
 const { ABox } = ABoxFile as jest.Mocked<typeof ABoxFile>;
@@ -60,6 +62,7 @@ const { ANav } = ANavFile as jest.Mocked<typeof ANavFile>;
 const { ARow } = ARowFile as jest.Mocked<typeof ARowFile>;
 const { ASection } = ASectionFile as jest.Mocked<typeof ASectionFile>;
 const { ASpacer } = ASpacerFile as jest.Mocked<typeof ASpacerFile>;
+const { ASubtitle } = ASubtitleFile as jest.Mocked<typeof ASubtitleFile>;
 const { ATextArea } = ATextAreaFile as jest.Mocked<typeof ATextAreaFile>;
 
 describe('Given aspire-components-react', () => {
@@ -84,6 +87,7 @@ describe('Given aspire-components-react', () => {
       ARow,
       ASection,
       ASpacer,
+      ASubtitle,
       ATextArea,
     });
   });

--- a/test/snapshot/ASubtitle.spec.tsx
+++ b/test/snapshot/ASubtitle.spec.tsx
@@ -1,0 +1,19 @@
+import { ASubtitle } from '../../src/ASubtitle/ASubtitle';
+import { AS_HEADING_ENUM } from '../enums/as-heading-enum';
+import { FONTSIZE_ENUM } from '../enums/fontsize-enum';
+import { TYPE_HEADING_ENUM } from '../enums/type-heading-enum';
+
+import { testComponent } from './utils/test-component';
+import { testTypography } from './utils/test-typography';
+
+describe('Given ASubtitle component is used', () => {
+  const ASubtitleProps = {
+    factory: {
+      fontSize: FONTSIZE_ENUM,
+    },
+  };
+
+  testComponent(ASubtitle, 'ASubtitle', ASubtitleProps);
+  testTypography(ASubtitle, 'ASubtitle', 'as', AS_HEADING_ENUM);
+  testTypography(ASubtitle, 'ASubtitle', 'type', TYPE_HEADING_ENUM);
+});

--- a/test/snapshot/__snapshots__/AH1.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH1.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH1 component is used When rendering AH1 with as set to "h6" Then
 </h1>
 `;
 
+exports[`Given AH1 component is used When rendering AH1 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h1
+  className="a-subtitle-1"
+>
+  AH1
+</h1>
+`;
+
+exports[`Given AH1 component is used When rendering AH1 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h1
+  className="a-subtitle-2"
+>
+  AH1
+</h1>
+`;
+
 exports[`Given AH1 component is used When rendering AH1 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h1"

--- a/test/snapshot/__snapshots__/AH2.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH2.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH2 component is used When rendering AH2 with as set to "h6" Then
 </h2>
 `;
 
+exports[`Given AH2 component is used When rendering AH2 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h2
+  className="a-subtitle-1"
+>
+  AH2
+</h2>
+`;
+
+exports[`Given AH2 component is used When rendering AH2 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h2
+  className="a-subtitle-2"
+>
+  AH2
+</h2>
+`;
+
 exports[`Given AH2 component is used When rendering AH2 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h2"

--- a/test/snapshot/__snapshots__/AH3.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH3.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH3 component is used When rendering AH3 with as set to "h6" Then
 </h3>
 `;
 
+exports[`Given AH3 component is used When rendering AH3 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h3
+  className="a-subtitle-1"
+>
+  AH3
+</h3>
+`;
+
+exports[`Given AH3 component is used When rendering AH3 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h3
+  className="a-subtitle-2"
+>
+  AH3
+</h3>
+`;
+
 exports[`Given AH3 component is used When rendering AH3 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h3"

--- a/test/snapshot/__snapshots__/AH4.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH4.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH4 component is used When rendering AH4 with as set to "h6" Then
 </h4>
 `;
 
+exports[`Given AH4 component is used When rendering AH4 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h4
+  className="a-subtitle-1"
+>
+  AH4
+</h4>
+`;
+
+exports[`Given AH4 component is used When rendering AH4 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h4
+  className="a-subtitle-2"
+>
+  AH4
+</h4>
+`;
+
 exports[`Given AH4 component is used When rendering AH4 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h4"

--- a/test/snapshot/__snapshots__/AH5.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH5.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH5 component is used When rendering AH5 with as set to "h6" Then
 </h5>
 `;
 
+exports[`Given AH5 component is used When rendering AH5 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h5
+  className="a-subtitle-1"
+>
+  AH5
+</h5>
+`;
+
+exports[`Given AH5 component is used When rendering AH5 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h5
+  className="a-subtitle-2"
+>
+  AH5
+</h5>
+`;
+
 exports[`Given AH5 component is used When rendering AH5 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h5"

--- a/test/snapshot/__snapshots__/AH6.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/AH6.spec.tsx.snap
@@ -154,6 +154,22 @@ exports[`Given AH6 component is used When rendering AH6 with as set to "h6" Then
 </h6>
 `;
 
+exports[`Given AH6 component is used When rendering AH6 with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<h6
+  className="a-subtitle-1"
+>
+  AH6
+</h6>
+`;
+
+exports[`Given AH6 component is used When rendering AH6 with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<h6
+  className="a-subtitle-2"
+>
+  AH6
+</h6>
+`;
+
 exports[`Given AH6 component is used When rendering AH6 with type set to "h1" Then the component should render as expected 1`] = `
 <h1
   className="a-h6"

--- a/test/snapshot/__snapshots__/ASubtitle.spec.tsx.snap
+++ b/test/snapshot/__snapshots__/ASubtitle.spec.tsx.snap
@@ -1,0 +1,227 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Given ASubtitle component is used When a developer uses ASubtitle with a className Then the the class should be present 1`] = `
+<strong
+  className="asdf a-subtitle-1"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses ASubtitle with no props Then the only class should be a-container 1`] = `
+<strong
+  className="a-subtitle-1"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 2xl Then the class fontSize-2xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-2xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 3xl Then the class fontSize-3xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-3xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 4xl Then the class fontSize-4xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-4xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 5xl Then the class fontSize-5xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-5xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 6xl Then the class fontSize-6xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-6xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 7xl Then the class fontSize-7xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-7xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 8xl Then the class fontSize-8xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-8xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in 9xl Then the class fontSize-9xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-9xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in an invalid value Then no fontSize class should be used 1`] = `
+<strong
+  className="a-subtitle-1"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in base Then the class fontSize-base should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-base"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in lg Then the class fontSize-lg should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-lg"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in sm Then the class fontSize-sm should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-sm"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in undefined Then no fontSize class should be used 1`] = `
+<strong
+  className="a-subtitle-1"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in xl Then the class fontSize-xl should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-xl"
+/>
+`;
+
+exports[`Given ASubtitle component is used When a developer uses a factory prop type When a developer uses the fontSize prop When a developer passes in xs Then the class fontSize-xs should be used 1`] = `
+<strong
+  className="a-subtitle-1 fontSize-xs"
+/>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h1" Then the component should render as expected 1`] = `
+<strong
+  className="a-h1"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h2" Then the component should render as expected 1`] = `
+<strong
+  className="a-h2"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h3" Then the component should render as expected 1`] = `
+<strong
+  className="a-h3"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h4" Then the component should render as expected 1`] = `
+<strong
+  className="a-h4"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h5" Then the component should render as expected 1`] = `
+<strong
+  className="a-h5"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "h6" Then the component should render as expected 1`] = `
+<strong
+  className="a-h6"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "subtitle-1" Then the component should render as expected 1`] = `
+<strong
+  className="a-subtitle-1"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with as set to "subtitle-2" Then the component should render as expected 1`] = `
+<strong
+  className="a-subtitle-2"
+>
+  ASubtitle
+</strong>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h1" Then the component should render as expected 1`] = `
+<h1
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h1>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h2" Then the component should render as expected 1`] = `
+<h2
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h2>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h3" Then the component should render as expected 1`] = `
+<h3
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h3>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h4" Then the component should render as expected 1`] = `
+<h4
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h4>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h5" Then the component should render as expected 1`] = `
+<h5
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h5>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "h6" Then the component should render as expected 1`] = `
+<h6
+  className="a-subtitle-1"
+>
+  ASubtitle
+</h6>
+`;
+
+exports[`Given ASubtitle component is used When rendering ASubtitle with type set to "strong" Then the component should render as expected 1`] = `
+<strong
+  className="a-subtitle-1"
+>
+  ASubtitle
+</strong>
+`;


### PR DESCRIPTION
### Description
Should create `ASubtitle` component that extends subtitle-1 and subtitle-2 from material spec.

### Outcomes
- [x] ASubtitle should be capable of displaying as subtitle-1
- [x] ASubtitle should be capable of displaying as subtitle-2
- [x] ASubtitle should default to displaying as subtitle-1

### Changes

- [x] Closes #73 
